### PR TITLE
方法onTimer的参数第一参数错误

### DIFF
--- a/src/04/swoole_after_server.php
+++ b/src/04/swoole_after_server.php
@@ -52,7 +52,7 @@ class Server
         $this->serv->send( $param['fd'] , $param['msg']);
     }
 
-    public function onTimer( $interval ) {
+    public function onTimer( $serv, $interval ) {
         // Do nothing.
     }
 }


### PR DESCRIPTION
方法onTimer的参数第一参数错误，会引起notice报错。此方法有两个参数
